### PR TITLE
PLAT-9278 - Include plugin.php before calling is_active_plugin()

### DIFF
--- a/src/PostTypes/Course.php
+++ b/src/PostTypes/Course.php
@@ -1218,6 +1218,7 @@ if (!class_exists('Course')) {
             }
 
             // Set course language if WPML exists
+            include_once(ABSPATH . 'wp-admin/includes/plugin.php');
             if (is_plugin_active(ADMWPP_WPML_PATH) && !empty($postArgs['meta_input'][TMS_LANGUAGE_KEY])) {
                 $langCode = strtolower($postArgs['meta_input'][TMS_LANGUAGE_KEY]);
                 if (in_array($langCode, array_keys(icl_get_languages()))) {


### PR DESCRIPTION
PLAT-9278 - Include plugin.php before calling is_active_plugin()

[https://administrate.atlassian.net/browse/PLAT-9278](https://administrate.atlassian.net/browse/PLAT-9278)

On some wordPress installations, is_plugin_active() is causing an error. we encountered this issue while trying to import courses. We need to include wordPress plugin.php file in the plugin Course post type file to avoid this issue.