### PR TITLE
PLAT-9250 Add a filter to set course meta keys to be synched to content

### DIFF
--- a/src/PostTypes/Course.php
+++ b/src/PostTypes/Course.php
@@ -1167,9 +1167,13 @@ if (!class_exists('Course')) {
                 }
 
                 // Post content is a contact of several custom fields from the TMS
-                global $TMS_COURSE_CONTENT;
+                // Use admwpp_course_content_meta_keys filter in active theme or plugins
+                // to set the course meta keys to be synched to the content
+                $tmsCourseContentMetaKeys = array();
+                $tmsCourseContentMetaKeys = apply_filters( 'admwpp_course_content_meta_keys', $tmsCourseContentMetaKeys);
+                
                 $content = '';
-                foreach ($TMS_COURSE_CONTENT as $fieldKey) {
+                foreach ($tmsCourseContentMetaKeys as $fieldKey) {
                     $content .= $postMetas[$fieldKey];
                     $content .= "<br/>";
                 }

--- a/src/globals.php
+++ b/src/globals.php
@@ -61,15 +61,6 @@ define('TMS_LANGUAGE_KEY', 'admwpp_tms_language');
 define('TMS_STICKY_POST_KEY', 'admwpp_tms_sticky_in_catalog');
 define('TMS_CUSTOM_PRICE_LEVEL_NAME', '*KP - 10 kinderen');
 
-
-global $TMS_COURSE_CONTENT;
-$TMS_COURSE_CONTENT = array(
-  'admwpp_tms_general_info',
-  'admwpp_tms_usps_info',
-  'admwpp_tms_price_info',
-  'admwpp_tms_practical_info',
-);
-
 global $TMS_LP_CUSTOM_FILEDS;
 $TMS_LP_CUSTOM_FILEDS = array(
   'admwpp_tms_language' => array(


### PR DESCRIPTION
PLAT-9250 Add a filter to set course meta keys to be synched to content

[https://administrate.atlassian.net/browse/PLAT-9250](https://administrate.atlassian.net/browse/PLAT-9250)

Add a filter that can be used in an active theme or plugins to set course meta keys to be synched to the content.