### PR TITLE
PLAT-9651 Add day of week filter to search page

### DIFF
--- a/src/Api/Search.php
+++ b/src/Api/Search.php
@@ -191,8 +191,12 @@ if (!class_exists('Search')) {
             $categoryFilterTemplate = self::getTemplatePath('category-filter');
             $dateFilterTemplate = self::getTemplatePath('date-filter');
             $locationsFilterTemplate = self::getTemplatePath('locations-filter');
+            $dayOfWeekTemplate = self::getTemplatePath('dayofweek-filter');
             $courseTemplate = self::getTemplatePath('course');
             $pagerTemplate = self::getTemplatePath('pager');
+
+            global $ADMWPP_SEARCH_DAYSOFWEEK;
+            $daysOfWeekFilter = apply_filters('admwpp_days_of_week_filter', $ADMWPP_SEARCH_DAYSOFWEEK);
 
             ob_start();
             include $template;

--- a/src/Api/Search.php
+++ b/src/Api/Search.php
@@ -120,6 +120,7 @@ if (!class_exists('Search')) {
             $vars[] = 'to';
             $vars[] = 'loc';
             $vars[] = 'per_page';
+            $vars[] = 'dayofweek';
             return $vars;
         }
 
@@ -154,22 +155,23 @@ if (!class_exists('Search')) {
                 'parent' => 0,
             ));
 
-            $query = get_query_var('query');
-            $lcat = get_query_var('lcat');
+            $query = get_query_var('query', '');
+            $lcat = get_query_var('lcat', array());
             $fromDate = get_query_var('from');
             $toDate = get_query_var('to');
-            $loc = get_query_var('loc');
+            $loc = get_query_var('loc', array());
+            $dayofweek = get_query_var('dayofweek', array());
+
             $page = get_query_var('paged') ? (int) get_query_var('paged') : 1;
             $per_page = (int) get_query_var('per_page', ADMWPP_SEARCH_PER_PAGE);
 
             $params = array(
+                'query' => $query,
                 'page' => $page,
                 'per_page' => $per_page,
+                'dayofweek' => $dayofweek,
             );
 
-            if ($query) {
-                $params['query'] = $query;
-            }
             if ($lcat) {
                 $params['lcat'] = $lcat;
             }
@@ -218,7 +220,7 @@ if (!class_exists('Search')) {
             $args = array(
                 'filters' => array(),
                 'customFieldFilters' => array(),
-                'search' => '',
+                'search' => $params['query'],
                 'fields' => self::$searchFields,
                 'paging' => array(
                     'page' => $page,
@@ -231,10 +233,6 @@ if (!class_exists('Search')) {
                 'returnType' => 'array', //array, obj, json
             );
 
-            if (isset($params['query']) && !empty($params['query'])) {
-                $args['search'] = $params['query'];
-            }
-
             if (isset($params['lcat']) && !empty($params['lcat'])) {
                 $args['filters'][] = array(
                     'field' => 'categoryId',
@@ -243,11 +241,11 @@ if (!class_exists('Search')) {
                 );
             }
 
-            if (isset($params['date']) && !empty($params['date'])) {
+            if (isset($params['dayofweek']) && !empty($params['dayofweek'])) {
                 $args['filters'][] = array(
-                    'field' => 'date',
-                    'operation' => 'eq',
-                    'value' => $params['date'],
+                    'field' => 'dayOfWeek',
+                    'operation' => 'in',
+                    'values' => $params['dayofweek'],
                 );
             }
 

--- a/src/globals.php
+++ b/src/globals.php
@@ -60,3 +60,17 @@ define('TMS_SHORT_DESCRIPTION_KEY', 'admwpp_tms_short_descripton');
 define('TMS_LANGUAGE_KEY', 'admwpp_tms_language');
 define('TMS_STICKY_POST_KEY', 'admwpp_tms_sticky_in_catalog');
 define('TMS_CUSTOM_PRICE_LEVEL_NAME', '*KP - 10 kinderen');
+
+// --------------------------------------------------------------------
+// Define Global variables for Search Filters page
+// --------------------------------------------------------------------
+global $ADMWPP_SEARCH_DAYSOFWEEK;
+$ADMWPP_SEARCH_DAYSOFWEEK = array(
+  'Mon' => 'Monday',
+  'Tue' => 'Tuesday',
+  'Wed' => 'Wednesday',
+  'Thu' => 'Thursday',
+  'Fri' => 'Friday',
+  'Sat' => 'Saturday',
+  'Sun' => 'Sunday',
+);

--- a/templates/search/dayofweek-filter.php
+++ b/templates/search/dayofweek-filter.php
@@ -1,0 +1,24 @@
+<div class="adwmpp-filter-wrapper adwmpp-dayofweek-wrapper locations-wrapper adwmpp-checkbox checkbox">
+    <h3 class="adwmpp-filter-title"><?php _e('Day Of Week', 'admwpp'); ?></h3>
+    <div class="adwmpp-checkbox-wrapper checkbox-wrapper">
+        <?php
+        foreach ($daysOfWeekFilter as $key => $value) {
+            $checked = "";
+            if (in_array('Mon', $dayofweek)) :
+                $checked = 'checked="checked"';
+            endif;
+            ?>
+            <div class="adwmpp-checkbox-item">
+                <input type="checkbox"
+                id="adwmpp-<?php echo $key; ?>"
+                name="dayofweek[]"
+                value="<?php echo $key; ?>" <?php echo $checked; ?>/>
+                <label for="adwmpp-<?php echo $key; ?>">
+                    <?php _e($value, 'admwpp'); ?>
+                </label>
+            </div>
+            <?php
+        }
+        ?>
+    </div>
+</div>

--- a/templates/search/form.php
+++ b/templates/search/form.php
@@ -41,7 +41,9 @@
             }
             if ($locationSettingsOption == 1) {
                 include($locationsFilterTemplate);
-            } ?>
+            }
+            include($dayOfWeekTemplate);
+            ?>
             <div class="adwmpp-dropdown-footer dropdown-footer">
                 <div class="adwmpp-links-wrapper links-wrapper">
                     <button class="adwmpp-filter-btn adwmpp-btn" value="<?php _e('Filter wissen', 'cga'); ?>">


### PR DESCRIPTION
In this PR we are adding the capability to filter on day of week a custom Event filter.
`filters:[
  {
    field: dayOfWeek,
    operation: in, 
    values: ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
  }
]
`
Also adding the days of week filter template with capability to filter on the labels to pass translations if needed, `admwpp_days_of_week_filter` or just limit to a subset of days.
https://administrate.atlassian.net/browse/PLAT-9651