### PR TITLE
PS-2447 pass shortcode params in search args to be able to set some condition based on

### DIFF
--- a/src/Api/Search.php
+++ b/src/Api/Search.php
@@ -171,6 +171,7 @@ if (!class_exists('Search')) {
                 'dayofweek' => $dayofweek,
                 'timeofday' => $timeofday,
                 'minplaces' => $minplaces,
+                'config' => $args,
             );
 
             if ($lcat) {
@@ -228,6 +229,7 @@ if (!class_exists('Search')) {
             $perPage = (int) $params['per_page'];
 
             $args = array(
+                'config' => $params['config'],
                 'filters' => array(),
                 'customFieldFilters' => array(),
                 'search' => $params['query'],


### PR DESCRIPTION
In this PR we are exposing the search short-code `admwpp-search-form` params to the search API args to be able to place some logic on custom filter usage on the theme/plugin level using the args filter `admwpp_search_args`  
https://administrate.atlassian.net/browse/PS-2447