### PR TITLE
PLAT-9655 Refactor Webhooks to Enable updating a webhooks from settin…

### DIFF
--- a/src/Controllers/WebhookController.php
+++ b/src/Controllers/WebhookController.php
@@ -22,18 +22,18 @@ class WebhookController extends Base\ActionController
             $instance = Settings::instance()->getSettingsOption('account', 'instance');
             if ($responceInstance === $instance) {
                 if (isset($body->payload->courseTemplates->edges[0])) {
-                    $node = $body->payload->courseTemplates->edges[0]->node;
-                    $node = json_decode(json_encode($node), true);
+                    $nodeId = $body->payload->courseTemplates->edges[0]->node->id;
+                    $node = Course::getNodeById($nodeId, 'COURSE');
                     $import = Course::nodeToPost($node, 'COURSE');
                 }
                 if (isset($body->payload->events->edges[0])) {
-                    $node = $body->payload->events->edges[0]->node->courseTemplate;
-                    $node = json_decode(json_encode($node), true);
+                    $nodeId = $body->payload->events->edges[0]->node->courseTemplate->id;
+                    $node = Course::getNodeById($nodeId, 'COURSE');
                     $import = Course::nodeToPost($node, 'COURSE');
                 }
                 if (isset($body->payload->learningPaths->edges[0])) {
-                    $node = $body->payload->learningPaths->edges[0]->node;
-                    $node = json_decode(json_encode($node), true);
+                    $nodeId = $body->payload->learningPaths->edges[0]->node->id;
+                    $node = Course::getNodeById($nodeId, 'LP');
                     $import = Course::nodeToPost($node, 'LP');
                 }
             }

--- a/src/Main.php
+++ b/src/Main.php
@@ -30,6 +30,8 @@ if (!class_exists('Main')) {
         protected $search;
         //Shortcodes
         protected $shortcodes;
+        //Webhooks
+        protected $webhooks;
 
         /**
          * Initializes plugin variables and sets up WordPress hooks/actions
@@ -87,6 +89,10 @@ if (!class_exists('Main')) {
 
                 // Add Shortcodes
                 $this->shortcodes = Shortcodes\Shortcode::instance();
+
+                //Add webhooks
+                $this->Webhooks = Webhooks\Webhook::instance();
+                $this->Webhooks->createSynchWebhooks();
 
                 // Add all filters
                 $this->addFilters();

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -61,6 +61,7 @@ if (!class_exists('Settings')) {
                 $className = __CLASS__;
                 self::$instance = new $className;
             }
+
             self::$instance->loadSettings();
             return self::$instance;
         }


### PR DESCRIPTION
In This PR we are refactoring the webhhok to accommodate for the PHPSDK update in query builder method also to make the webhook update once the settings are saved in order to accommodate for any changes brought to the query saved in those webhooks config.
Also to change to payload sent back to the website from being a full Course / LP GraphQL response on the course or LP to just returning the ID of that Course and LP and the website sending a call to the TMS Core API to fetch the course content to synch this way any change we introduce to Query fetching the courser or LP will be immediately reflected in the webhooks, also this change will pave the ground to the next enhancement of buffering the Callbacks incase many webhook call backs hits the website at once (or from a bulk update in the TMS).
https://administrate.atlassian.net/browse/PLAT-9655