### PR TITLE
PS-3462 Revisit date filter applying changes to date format and splitting the date filter agrs

### DIFF
--- a/src/Api/Search.php
+++ b/src/Api/Search.php
@@ -290,22 +290,23 @@ if (!class_exists('Search')) {
                 );
             }
 
-            if (isset($params['from']) && !empty($params['from'])
-                && isset($params['to']) && !empty($params['to'])) {
+            $timeZoneString = wp_timezone_string();
+            $today = new \DateTime("now", new \DateTimeZone($timeZoneString));
+            $timezoneOffset = $today->format('P');
+
+            if (isset($params['from']) && !empty($params['from'])) {
                 $from = date('Y-m-d', strtotime($params['from']));
-                $to = date('Y-m-d', strtotime($params['to']));
-
-                $timeZoneString = wp_timezone_string();
-                $today = new \DateTime("now", new \DateTimeZone($timeZoneString));
-                $timezoneOffset = $today->format('P');
                 $from .= "T00:00:00" . $timezoneOffset;
-                $to .= "T23:59:59" . $timezoneOffset;
-
                 $args['filters'][] = array(
                     'field' => 'start',
                     'operation' => 'ge',
                     'value' => $from,
                 );
+            }
+
+            if (isset($params['to']) && !empty($params['to'])) {
+                $to = date('Y-m-d', strtotime($params['to']));
+                $to .= "T23:59:59" . $timezoneOffset;
                 $args['filters'][] = array(
                     'field' => 'end',
                     'operation' => 'le',

--- a/src/Api/Search.php
+++ b/src/Api/Search.php
@@ -295,7 +295,7 @@ if (!class_exists('Search')) {
             $timezoneOffset = $today->format('P');
 
             if (isset($params['from']) && !empty($params['from'])) {
-                $from = date('Y-m-d', strtotime($params['from']));
+                $from = date(ADMWPP_SEARCH_DATE_GQL_FORMAT, strtotime($params['from']));
                 $from .= "T00:00:00" . $timezoneOffset;
                 $args['filters'][] = array(
                     'field' => 'start',
@@ -305,7 +305,7 @@ if (!class_exists('Search')) {
             }
 
             if (isset($params['to']) && !empty($params['to'])) {
-                $to = date('Y-m-d', strtotime($params['to']));
+                $to = date(ADMWPP_SEARCH_DATE_GQL_FORMAT, strtotime($params['to']));
                 $to .= "T23:59:59" . $timezoneOffset;
                 $args['filters'][] = array(
                     'field' => 'end',

--- a/src/Main.php
+++ b/src/Main.php
@@ -590,7 +590,7 @@ if (!class_exists('Main')) {
                 'routeUrl' => ADMWPP_URL_ROUTES,
                 'ajaxUrl' => admin_url('admin-ajax.php'),
                 'search' => array(
-                    'dateFormat' => ADMWPP_SEARCH_DATE_FORMAT,
+                    'dateFormat' => ADMWPP_SEARCH_DATE_DISPLAY_FORMAT,
                     'perPage' => ADMWPP_SEARCH_PER_PAGE
                 ),
                 'giftVoucher' => array(

--- a/src/globals.php
+++ b/src/globals.php
@@ -42,10 +42,13 @@ if (!defined('ADMWPP_NO_WEBLINK')) {
 // Define Global variables For Search
 // --------------------------------------------------------------------
 define('ADMWPP_SEARCH_PER_PAGE', 10);
+define('ADMWPP_SEARCH_DATE_GQL_FORMAT', 'Y-m-d');
 
-if (!defined('ADMWPP_SEARCH_DATE_FORMAT')) {
-    define('ADMWPP_SEARCH_DATE_FORMAT', 'mm-dd-yy');
+if (!defined('ADMWPP_SEARCH_DATE_DISPLAY_FORMAT')) {
+    define('ADMWPP_SEARCH_DATE_DISPLAY_FORMAT', 'mm-dd-yy');
 }
+
+
 
 // --------------------------------------------------------------------
 // Define Global variables add a selection Block

--- a/src/globals.php
+++ b/src/globals.php
@@ -42,7 +42,10 @@ if (!defined('ADMWPP_NO_WEBLINK')) {
 // Define Global variables For Search
 // --------------------------------------------------------------------
 define('ADMWPP_SEARCH_PER_PAGE', 10);
-define('ADMWPP_SEARCH_DATE_FORMAT', 'mm/dd/yy');
+
+if (!defined('ADMWPP_SEARCH_DATE_FORMAT')) {
+    define('ADMWPP_SEARCH_DATE_FORMAT', 'mm-dd-yy');
+}
 
 // --------------------------------------------------------------------
 // Define Global variables add a selection Block


### PR DESCRIPTION
This PR changes the default date filter format used for the date filter date-picker with exposing ability to override on the theme level.
Also Prior to this change we used to only allow from and to date filters to be passed as filter args, after this change we have split those into individual filter args.
https://administrate.atlassian.net/browse/PS-3462