### PR TITLE
Revert "PS-3562 Add Active Only Locations"

### DIFF
--- a/src/Api/Search.php
+++ b/src/Api/Search.php
@@ -528,20 +528,15 @@ if (!class_exists('Search')) {
             $client = new SDKClient($apiParams['apiUri'], $authorizationHeaders);
 
             $gql = 'query locations {
-                locations(filters: [{
-                  field: status,
-                  operation: eq
-                  value: "active"
-                }]) {
-                  edges {
-                    node {
-                      id
-                      name
-                      status
-                    }
+              locations {
+                edges {
+                  node {
+                    id
+                    name
                   }
                 }
-              }';
+              }
+            }';
 
             $results = $client->runRawQuery($gql);
             $data = $results->getData();


### PR DESCRIPTION
Reverts Administrate/administrate-wp-plugin#131

The reason for this revert is that now on weblink-api we only return `active` locations so no need to do any sort of filtering