### PR TITLE
PS-3575 Fix varialbe name used to pass post id number in loadmore pager for bundle shortcode template

### DIFF
--- a/templates/shortcode/bundled-lps.php
+++ b/templates/shortcode/bundled-lps.php
@@ -1,11 +1,11 @@
 <?php
 global $post;
-$postId = 0;
+$post_id = 0;
 if (isset($post)) {
-    $postId = $post->ID;
+    $post_id = $post->ID;
 }
 if (isset($_GET['post_id'])) {
-    $postId = $_GET['post_id'];
+    $post_id = $_GET['post_id'];
 }
 ?>
 <div id='amwpp-bundled-lps' class="admwpp-bundled-lps row justify-content-center">


### PR DESCRIPTION
In this PR we are making sure the variable used to pass the post Id for course / LP is consistent across all sourtcode template and used properly for loadmore pagination.
https://administrate.atlassian.net/browse/PS-3575