### PR TITLE
PS-3569 Rename Locations To All Locations

### DIFF
--- a/templates/search/locations-filter.php
+++ b/templates/search/locations-filter.php
@@ -6,7 +6,7 @@ $locationsFilter = ADM\WPPlugin\Api\Search::getLocationsFilter();
         <div class="adwmpp-dropdown-body dropdown-body">
             <select class="admwpp-select admwpp-custom-select" name="loc[]" multiple>
                 <option class="adwmpp-option-item option-item" value="">
-                    <?php _e('Locations', 'admwpp'); ?>
+                    <?php _e('All Locations', 'admwpp'); ?>
                 </option>
                 <?php
                 if ($locationsFilter) :


### PR DESCRIPTION
To avoid confusion, we want to rename the dropdown filter of locations option `Locations` to become `All Locations`
This will help anyone seeing the filter understand we are selecting all the locations instead of confusing them