### PR TITLE
PS-3529 Add option to select the duration to save search categories and location filters values

### DIFF
--- a/src/Api/Search.php
+++ b/src/Api/Search.php
@@ -563,7 +563,11 @@ if (!class_exists('Search')) {
                 foreach ($data->locations->edges as $key => $edge) {
                     $locations[$edge->node->id] = $edge->node->name;
                 }
-                set_transient(ADMWPP_TRANS_TMS_LOCATIONS, $locations, WEEK_IN_SECONDS);
+                set_transient(
+                    ADMWPP_TRANS_TMS_LOCATIONS,
+                    $locations,
+                    Settings::instance()->getTransientsDuration()
+                );
                 return $locations;
             }
             return array();

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -38,8 +38,9 @@ if (!class_exists('Settings')) {
         static $TRANSIENTS_DURATION = array(
             'one_hour' => HOUR_IN_SECONDS,
             'two_hours' => HOUR_IN_SECONDS * 2,
-            'foor_hours' => HOUR_IN_SECONDS * 4,
+            'four_hours' => HOUR_IN_SECONDS * 4,
             'six_hours' => HOUR_IN_SECONDS * 6,
+            'half_day' => DAY_IN_SECONDS / 2,
             'day' => DAY_IN_SECONDS,
             'week' => WEEK_IN_SECONDS,
             'month' => MONTH_IN_SECONDS,

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -35,6 +35,19 @@ if (!class_exists('Settings')) {
 
         private $plugin_settings_tabs   = array();
 
+        static $TRANSIENTS_DURATION = array(
+            'one_hour' => HOUR_IN_SECONDS,
+            'two_hours' => HOUR_IN_SECONDS * 2,
+            'foor_hours' => HOUR_IN_SECONDS * 4,
+            'six_hours' => HOUR_IN_SECONDS * 6,
+            'day' => DAY_IN_SECONDS,
+            'week' => WEEK_IN_SECONDS,
+            'month' => MONTH_IN_SECONDS,
+            'year' => YEAR_IN_SECONDS,
+        );
+
+        static $TRANSIENTS_DEFAULT_DURATION = 'day';
+
         function __construct()
         {
             // Add all actions and filters
@@ -186,6 +199,27 @@ if (!class_exists('Settings')) {
                 return $value;
             }
             return false;
+        }
+
+        /*
+         * Get get Transients Duration value from settings instance.
+         */
+        public function getTransientsDuration()
+        {
+            $transientDurationKey = self::getSettingsOption('search', 'transients_duration');
+            if ($transientDurationKey) {
+                return self::$TRANSIENTS_DURATION[$transientDurationKey];
+            }
+            return self::$TRANSIENTS_DURATION[self::$TRANSIENTS_DEFAULT_DURATION];
+        }
+
+        public function getTransientsDurationOptions()
+        {
+            $options = array();
+            foreach (array_keys(self::$TRANSIENTS_DURATION) as $value) {
+                $options[$value] = ucwords(str_replace("_", " ", $value));
+            }
+            return $options;
         }
 
         /*
@@ -347,12 +381,14 @@ if (!class_exists('Settings')) {
 
             $settings_index = 'search';
 
-            //Reset transients flags
-            $settings['transients'] = array();
             if (empty($settings)) {
                 //Setup defaults
                 $settings['search_suggestions'] = 0;
+                $settings['transients_duration'] = self::$TRANSIENTS_DEFAULT_DURATION;
             }
+
+            //Reset transients flags
+            $settings['transients'] = array();
 
             $this->settings[$settings_index] = $settings;
             update_option($settings_key, $settings);
@@ -527,9 +563,27 @@ if (!class_exists('Settings')) {
 
             add_settings_section(
                 'admwpp_search_trans_section',
-                "<span class='admwpp-section-title'>" . __('Search Filters Validation Transients', ADMWPP_TEXT_DOMAIN) . "</span>",
+                "<span class='admwpp-section-title'>" . __('Search Filters Transients', ADMWPP_TEXT_DOMAIN) . "</span>",
                 array(),
                 "admwpp_" . $settings_key . "_settings"
+            );
+
+            add_settings_field(
+                'admwpp_clear_search_transients_duration',
+                __('Select transients duration:', ADMWPP_TEXT_DOMAIN),
+                array($this, 'settingsFieldSelect'),
+                "admwpp_" . $settings_key . "_settings",
+                'admwpp_search_trans_section',
+                array(
+                    'field'        => 'transients_duration',
+                    'settings_key' => $settings_key,
+                    'section_key'  => '',
+                    'options'      => self::getTransientsDurationOptions(),
+                    'disabled'     => '',
+                    'info'         => __('Select a Duration for the Transients', ADMWPP_TEXT_DOMAIN),
+                    'type'         => 'select',
+                    'allow_null'   => false,
+                )
             );
 
             add_settings_field(

--- a/src/Taxonomies/LearningCategory.php
+++ b/src/Taxonomies/LearningCategory.php
@@ -179,7 +179,12 @@ if (! class_exists('LearningCategory')) {
                 }
             }
 
-            set_transient(ADMWPP_TRANS_TMS_LC_IDS, $tmsIds, WEEK_IN_SECONDS);
+            set_transient(
+                ADMWPP_TRANS_TMS_LC_IDS,
+                $tmsIds,
+                Settings::instance()->getTransientsDuration()
+            );
+
             return $tmsIds;
         }
 


### PR DESCRIPTION
In the PR we are adding the ability to set the duration of caching using transients for the search page category and location filters values.
https://administrate.atlassian.net/browse/PS-3529
![Screen Shot 2022-01-17 at 5 27 08 PM](https://user-images.githubusercontent.com/58948488/149798284-4216e3e3-04b7-439f-9178-95836afc7c80.png)

