### PR TITLE
PS-3486 Update Search filter using weblink-api to fetch and save the Categories as filter options.

### DIFF
--- a/assets/sass/template-views/search.scss
+++ b/assets/sass/template-views/search.scss
@@ -69,6 +69,12 @@
     }
     .adwmpp-dropdown-body {
         margin-bottom: 15px;
+        .admwpp-has-children {
+            background-color: #6c757d;
+        }
+        .admwpp-child-item {
+            padding-left: 10px;
+        }
     }
     .selectric-wrapper {
         width: 100%;

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -598,8 +598,9 @@ if (!class_exists('Settings')) {
                     'settings_key' => $settings_key,
                     'section_key'  => '',
                     'options'      => array(
-                        ADMWPP_TRANS_TMS_LC_IDS => 'Categories',
-                        ADMWPP_TRANS_TMS_LOCATIONS => 'Location',
+                        ADMWPP_TRANS_TMS_LC_IDS => 'Categories TMS Ids',
+                        ADMWPP_TRANS_TMS_CATEGORIES => 'Categories Filter',
+                        ADMWPP_TRANS_TMS_LOCATIONS => 'Location Filter',
                     ),
                     'disabled'     => '',
                     'info'         => __('Validation transients selection will be reset after saving the settings', ADMWPP_TEXT_DOMAIN),

--- a/src/globals.php
+++ b/src/globals.php
@@ -57,6 +57,7 @@ define('ADMWPP_PER_PAGE', 20);
 // Define Global For Transients Keys
 // --------------------------------------------------------------------
 define('ADMWPP_TRANS_TMS_LOCATIONS', 'admwpp_tms_locations');
+define('ADMWPP_TRANS_TMS_CATEGORIES', 'admwpp_tms_categories');
 define('ADMWPP_TRANS_TMS_LC_IDS', 'admwpp_tms_categories_ids');
 
 // --------------------------------------------------------------------

--- a/templates/search/category-filter.php
+++ b/templates/search/category-filter.php
@@ -1,64 +1,46 @@
 <?php
-$categories = get_terms(array(
-    'taxonomy' => 'learning-category',
-    'hide_empty' => true,
-    'parent' => 0,
-));
+$categoriesFilter = ADM\WPPlugin\Api\Search::getCategoriesFilter();
 ?>
 <div class="adwmpp-filter-wrapper adwmpp-categories-wrapper categories-wrapper adwmpp-dropdown dropdown">
     <div class="adwmpp-dropdown-wrapper dropdown-wrapper">
         <div class="adwmpp-dropdown-body dropdown-body">
-            <?php if (!empty($categories)) :
-                if ($categories_filter_type == 'select') : ?>
-                    <select class="admwpp-select admwpp-custom-select" name="lcat[]" multiple autocomplete="off">
-                        <option class="adwmpp-option-item option-item" value="">
-                            <?php _e("Categories", 'admwpp'); ?>
-                        </option>
-                        <?php foreach ($categories as $category) :
-                            $admwpp_tms_id = get_term_meta($category->term_id, 'admwpp_tms_id', true);
-                            if ($admwpp_tms_id) :
+            <?php if (!empty($categoriesFilter)) : ?>
+                <select class="admwpp-select admwpp-custom-select" name="lcat[]" multiple autocomplete="off">
+                    <option class="adwmpp-option-item option-item" value="">
+                        <?php _e("Categories", 'admwpp'); ?>
+                    </option>
+                    <?php foreach ($categoriesFilter as $tmsId => $category) :
+                        $categoryName = $category['name'];
+                        $selected = "";
+                        $class = "";
+                        if (in_array($tmsId, $lcat)) {
+                            $selected = "selected='selected'";
+                        }
+                        if (isset($category['children'])) {
+                            $children = $category['children'];
+                            $class = 'admwpp-has-children';
+                        }
+                        ?>
+                        <option class="adwmpp-option-item option-item <?php echo $class; ?>" value="<?php echo $tmsId; ?>"
+                        <?php echo $selected; ?>><?php echo __($categoryName, 'admwpp'); ?></option>
+                        <?php
+                        if (isset($children)) {
+                            foreach ($children as $tmsId => $childName) {
+                                $class = 'admwpp-child-item';
                                 $selected = "";
-                                if (in_array($admwpp_tms_id, $lcat)) {
+                                if (in_array($tmsId, $lcat)) {
                                     $selected = "selected='selected'";
                                 }
                                 ?>
-                                <option class="adwmpp-option-item option-item" value="<?php echo $admwpp_tms_id; ?>"
-                                <?php echo $selected; ?>>
-                                    <?php echo __($category->name, 'admwpp'); ?>
-                                </option>
+                                <option class="adwmpp-option-item option-item <?php echo $class; ?>" value="<?php echo $tmsId; ?>"
+                                <?php echo $selected; ?>><?php echo __($childName, 'admwpp'); ?></option>
                                 <?php
-                            endif;
-                        endforeach;
-                        ?>
-                    </select>
-                <?php else : ?>
-                    <ul class="admwpp-category-listing">
-                        <?php foreach ($categories as $category) :
-                            $admwpp_tms_id = get_term_meta($category->term_id, 'admwpp_tms_id', true);
-                            if ($admwpp_tms_id) :
-                                $checked = "";
-                                if (in_array($admwpp_tms_id, $lcat)) {
-                                    $checked = "checked='checked'";
-                                }
-                                ?>
-                                <li class="adwmpp-checkbox-item checkbox-item">
-                                    <input type="radio" class="adwmpp-checkbox-input checkbox-input"
-                                    id="learning-cat-<?php echo $category->term_id; ?>"
-                                    name="lcat[]"
-                                    value="<?php echo $admwpp_tms_id; ?>"
-                                    <?php echo $checked; ?>
-                                    />
-                                    <label for="learning-cat-<?php echo $category->term_id; ?>">
-                                        <?php echo $category->name; ?>
-                                    </label>
-                                </li>
-                                <?php
-                            endif;
-                        endforeach;
-                        ?>
-                    </ul>
-                <?php endif;
-            endif; ?>
+                            }
+                        }
+                    endforeach;
+                    ?>
+                </select>
+            <?php endif; ?>
         </div>
     </div>
 </div>


### PR DESCRIPTION
In this commit we made the search category filter display categories for courses from weblink-api the same way as the location filter dose.
This will make sure that the categories visible in the search are similar to the one available for the configured portal in the plugin settings page.
Prior to this update the Categories where fetched and displayed from WordPress synched categories.
https://administrate.atlassian.net/browse/PS-3486