### PR TITLE
NI-4186 Update Gift Voucher widget defined constants to default to a new value of 1

### DIFF
--- a/src/Main.php
+++ b/src/Main.php
@@ -602,6 +602,7 @@ if (!class_exists('Main')) {
                         'notNumber' => _x(ADMWPP_NOT_NUMBER_MESSAGE, 'Gift Voucher', 'admwpp'),
                         'emptyAmount' => sprintf(
                             _x(ADMWPP_VOUCHER_EMPTY_AMOUNT_MESSAGE, 'Gift Voucher', 'admwpp'),
+                            ADMWPP_MIN_VOUCHER_AMOUNT,
                             ADMWPP_VOUCHER_CURRENCY
                         ),
                         'maxAmount' => sprintf(

--- a/src/globals.php
+++ b/src/globals.php
@@ -20,19 +20,19 @@ if (!defined('ADMWPP_VOUCHER_CURRENCY_CODE')) {
 if (!defined('ADMWPP_NOT_NUMBER_MESSAGE')) {
     define(
         'ADMWPP_NOT_NUMBER_MESSAGE',
-        'Please enter a valid number.'
+        _x('Please enter a valid number', 'Gift Voucher', 'admwpp')
     );
 }
 if (!defined('ADMWPP_VOUCHER_EMPTY_AMOUNT_MESSAGE')) {
     define(
         'ADMWPP_VOUCHER_EMPTY_AMOUNT_MESSAGE',
-        'Gift voucher is below the minimum value of 0.01 %s'
+        _x('Gift voucher is below the minimum value of %s %s', 'Gift Voucher', 'admwpp')
     );
 }
 if (!defined('ADMWPP_VOUCHER_MAX_AMOUNT_MESSAGE')) {
     define(
         'ADMWPP_VOUCHER_MAX_AMOUNT_MESSAGE',
-        'Gift voucher is above the maximum value of %s %s'
+        _x('Gift voucher is above the maximum value of %s %s', 'Gift Voucher', 'admwpp')
     );
 }
 if (!defined('ADMWPP_NO_WEBLINK')) {

--- a/src/globals.php
+++ b/src/globals.php
@@ -3,13 +3,13 @@
 // Define Global variables For GIFT Voucher
 // --------------------------------------------------------------------
 if (!defined('ADMWPP_MIN_VOUCHER_AMOUNT')) {
-    define('ADMWPP_MIN_VOUCHER_AMOUNT', 0.01);
+    define('ADMWPP_MIN_VOUCHER_AMOUNT', 1);
 }
 if (!defined('ADMWPP_MAX_VOUCHER_AMOUNT')) {
     define('ADMWPP_MAX_VOUCHER_AMOUNT', 250.00);
 }
 if (!defined('ADMWPP_VOUCHER_AMOUNT_STEP')) {
-    define('ADMWPP_VOUCHER_AMOUNT_STEP', 0.01);
+    define('ADMWPP_VOUCHER_AMOUNT_STEP', 1);
 }
 if (!defined('ADMWPP_VOUCHER_CURRENCY')) {
     define('ADMWPP_VOUCHER_CURRENCY', '€');


### PR DESCRIPTION
Prior to this PR the Gift Voucher constants ADMWPP_MIN_VOUCHER_AMOUNT and ADMWPP_VOUCHER_AMOUNT_STEP where set to default to 0.01 but now we are updating those to default to 1 as its more relevant from users perspective but keeping the ability to override those at any moment using wp-config.php if need be.

For CGA on wordpress backend we need to update translations:
De waarde van de cadeaubon is lager dan het minimum van 0.01 %s to use `van %s %s`
Le chèque-cadeau est inférieur à la valeur minimum de 0.01 %s to use `van %s %s`

https://administrate.atlassian.net/browse/NI-4186