### PR TITLE
PLAT-15138 adding a new custom filter `admwpp_course_post_status`

### DIFF
--- a/src/PostTypes/Course.php
+++ b/src/PostTypes/Course.php
@@ -128,6 +128,12 @@ if (!class_exists('Course')) {
                 'tmsKey' => 'events',
                 'showOnFront' => false,
             ),
+            'admwpp_tms_is_bundle' => array(
+                'type' => 'text',
+                'label' => 'isBundle',
+                'tmsKey' => 'isBundle',
+                'showOnFront' => false,
+            ),
         );
 
         static $inlineMetas = array();
@@ -225,6 +231,7 @@ if (!class_exists('Course')) {
             'code',
             'name',
             'description',
+            'isBundle',
             'image' => array(
                 'id',
                 'name',
@@ -1457,6 +1464,13 @@ if (!class_exists('Course')) {
                             }
                         }
                         $tmsValue = implode('|', $locationIds);
+                        break;
+                    case 'isBundle':
+                        if ($node[$tmsKey]) {
+                            $tmsValue = 'true';
+                        } else {
+                            $tmsValue = 'false';
+                        }
                         break;
                     default:
                         if (isset($node[$tmsKey])) {

--- a/src/PostTypes/Course.php
+++ b/src/PostTypes/Course.php
@@ -1223,18 +1223,19 @@ if (!class_exists('Course')) {
                 $title = $node['name'];
             }
 
+            $postStatus = 'pending';
             $postArgs = array(
                 'post_type' => self::$slug,
                 'post_title' => $title,
                 'post_name' => sanitize_title($title),
                 'post_content' => '',
-                'post_status' => 'pending',
+                'post_status' => $postStatus,
             );
 
             // "published" is used for Courses
             // "active" is used for LPs
             if ($node['lifecycleState'] === 'published' || $node['lifecycleState'] === 'active') {
-                $postArgs['post_status'] = 'publish';
+                $postStatus = 'publish';
             }
 
             // Process Custom Fields
@@ -1483,6 +1484,11 @@ if (!class_exists('Course')) {
                     }
                 }
             }
+
+            // Use admwpp_course_post_status to alter the post status based on synced post meta values
+            // To be used to apply some custom handling on special meta values condition based on client integrations
+            $postStatus = apply_filters('admwpp_course_post_status', $postStatus, $type, $postMetas, $node);
+            $postArgs['post_status'] = $postStatus;
 
             $content = '';
             if ('LP' == $type) {


### PR DESCRIPTION
In this PR we are adding a new custom filter `admwpp_course_post_status` to enable us / devs to alter the course post status based on synched most meta values to WordPress.
**Example:** For Maersk, we need to be able to hide the LPs that have `isBundle` set to true so on the theme level we can use the filter to override the post_status and make all the LPs with is a bundle set to true have the status as pending and hidden from the public as it's needed for Maersk, also this will propagate to the views created for the title suggestions.
The usage of this filter can extend to other conditions to set the post_status as needed like TMS custom filed values that are also synched to WordPress such as the example `show_in_catalogue` custom field. (CGA / Maersk)
In this PR as well we are extending the default synched core fields into WordPress by adding the `isBundle` LP core filed to the backfill and webhooks updates import/update methods.
https://administrate.atlassian.net/browse/PLAT-15138