### PR TITLE
NI-4953 Change part of day afternoon and evening endtime

### DIFF
--- a/src/Api/Search.php
+++ b/src/Api/Search.php
@@ -347,19 +347,19 @@ if (!class_exists('Search')) {
                 switch ($params['timeofday']) {
                     case 'morning':
                         $sessionStartTime = "00:00:00";
-                        $sessionEndTime = "11:59:59";
+                        $sessionEndTime = "00:01:00";
                         break;
                     case 'afternoon':
                         $sessionStartTime = "12:00:00";
-                        $sessionEndTime = "16:59:59";
+                        $sessionEndTime = "17:01:00";
                         break;
                     case 'evening':
                         $sessionStartTime = "17:00:00";
-                        $sessionEndTime = "23:59:59";
+                        $sessionEndTime = "00:01:00";
                         break;
                     default:
                         $sessionStartTime = "00:00:00";
-                        $sessionEndTime = "23:59:59";
+                        $sessionEndTime = "11:59:59";
                         break;
                 }
 


### PR DESCRIPTION
NI-4953 Change part of day afternoon and evening endtime

[https://administrate.atlassian.net/browse/NI-4953](https://administrate.atlassian.net/browse/NI-4953)

We had to change the part of day afternoon and evening endtime value and update it with 1 min overlap.
Basically the courses that have events starting at `14:00` and ending at `17:00` don't appear in the results when a user filters by `part of day` and selects afternoon, and the main reason for that is that the `end time` field is being set to `17:00:59` instead of `16:59:59`.