### PR TITLE
NI-4953 Fix part of day morning endtime

### DIFF
--- a/src/Api/Search.php
+++ b/src/Api/Search.php
@@ -347,7 +347,7 @@ if (!class_exists('Search')) {
                 switch ($params['timeofday']) {
                     case 'morning':
                         $sessionStartTime = "00:00:00";
-                        $sessionEndTime = "00:01:00";
+                        $sessionEndTime = "12:01:00";
                         break;
                     case 'afternoon':
                         $sessionStartTime = "12:00:00";


### PR DESCRIPTION
NI-4953 Fix part of day morning endtime

[https://administrate.atlassian.net/browse/NI-4953](https://administrate.atlassian.net/browse/NI-4953)

The part of day morning end time should be `12:01:00` instead of `00:01:00`