### PR TITLE
PLAT-20074 add weblink-client to weblink api call headers

### DIFF
--- a/src/Controllers/ActivationController.php
+++ b/src/Controllers/ActivationController.php
@@ -23,17 +23,10 @@ class ActivationController extends Base\ActionController
 
         update_option('admwpp_active', 0);
 
-        $params = self::$params;
-
-        $instance = $params['admwpp_account_settings']['instance'];
-        $app_id = $params['admwpp_account_settings']['app_id'];
-        $app_secret = $params['admwpp_account_settings']['app_secret'];
-        $portal = $params['admwpp_account_settings']['portal'];
-
-        Settings::instance()->setSettingsOption('account', 'instance', $instance);
-        Settings::instance()->setSettingsOption('account', 'app_id', $app_id);
-        Settings::instance()->setSettingsOption('account', 'app_secret', $app_secret);
-        Settings::instance()->setSettingsOption('account', 'portal', $portal);
+        $params = self::$params['admwpp_account_settings'];
+        foreach ($params as $key => $value) {
+            Settings::instance()->setSettingsOption('account', $key, $value);
+        }
 
         $activate = Oauth2\Activate::instance();
 

--- a/src/Oauth2/Activate.php
+++ b/src/Oauth2/Activate.php
@@ -26,6 +26,7 @@ if (!class_exists('Activate')) {
         static $oauth_server;
         static $activationObj;
         static $params;
+        static $weblink_client = '';
 
         // Grace Period to refresh token at 90%
         // of Expires IN.
@@ -85,6 +86,8 @@ if (!class_exists('Activate')) {
 
             if ($weblink) {
                 self::$params = $ADMWPP_APP_ENVIRONMENT[ADMWPP_ENV]['weblink'];
+                self::setWeblinkClient();
+                self::$params['client'] = self::$weblink_client;
             }
 
             self::setRedirectUri();
@@ -412,6 +415,21 @@ if (!class_exists('Activate')) {
         {
             //self::$redirect_uri = ADMWPP_URL_ROUTES .'?_uri=oauth/callback';
             self::$redirect_uri = site_url() . "/wp-json/admwpp/oauth/callback";
+        }
+
+        /**
+         * Sets the Weblink Client Identifier.
+         *
+         * @return void
+         *
+         * */
+        protected static function setWeblinkClient()
+        {
+            if (defined('ADMWPP_WEBLINK_CLIENT') && ADMWPP_WEBLINK_CLIENT !== '') {
+                self::$weblink_client = ADMWPP_WEBLINK_CLIENT;
+            } else {
+                self::$weblink_client = Settings::instance()->getSettingsOption('account', 'client');
+            }
         }
 
         /**

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -289,6 +289,10 @@ if (!class_exists('Settings')) {
 
             $settings_index = 'account';
 
+            if (!isset($settings) && empty($settings)) {
+                $settings['client'] = sanitize_title(get_bloginfo('name'));
+            }
+
             $this->settings[$settings_index] = $settings;
             update_option($settings_key, $settings);
 
@@ -500,6 +504,20 @@ if (!class_exists('Settings')) {
                     'settings_key' => $settings_key,
                     'placeholder'  => 'Portal',
                     'info'         => '<i>' . __('Portal Url to connect to', ADMWPP_TEXT_DOMAIN) . '</i>',
+                )
+            );
+
+            add_settings_field(
+                'admwpp-client',
+                __('Client Identifier:', ADMWPP_TEXT_DOMAIN),
+                array($this, 'settingsFieldInput'),
+                "admwpp_" . $settings_key . "_settings",
+                'admwpp_account_weblink_section',
+                array(
+                    'field'        => 'client',
+                    'settings_key' => $settings_key,
+                    'placeholder'  => 'xxx-booking-portal, xxx-website-staging, xxx-website-prod ',
+                    'info'         => '<i>' . __('Client Identifier to be added in API headers', ADMWPP_TEXT_DOMAIN) . '<br/> This field value can be defined/overridden using ADMWPP_WEBLINK_CLIENT in wp-config.php</i>',
                 )
             );
         }

--- a/vendor/administrate/phpsdk/README.md
+++ b/vendor/administrate/phpsdk/README.md
@@ -149,6 +149,7 @@ $activationParams = [
     'oauthServer' => 'https://portal-auth.administratehq.com', // Administrate weblink authorization endpoint
     'apiUri' => 'https://weblink-api.administratehq.com/graphql', // Administrate Weblink endpoint
     'portal' => 'APPNAME.administrateweblink.com',
+    'client' => 'CLIENT_INITIALS-booking-portal',
 ];
 
 // Create Activate Class instance
@@ -174,6 +175,7 @@ $params = [
     'oauthServer' => 'https://portal-auth.administratehq.com', // Administrate weblink authorization endpoint
     'apiUri' => 'https://weblink-api.administratehq.com/graphql', // Administrate Weblink endpoint
     'portal' => 'APPNAME.administrateweblink.com',
+    'client' => 'CLIENT_INITIALS-booking-portal',
     'portalToken' => 'Tcdg...DIY9o',
 ];
 
@@ -224,6 +226,7 @@ $params = [
     'oauthServer' => 'https://portal-auth.administratehq.com', // Administrate weblink authorization endpoint
     'apiUri' => 'https://weblink-api.administratehq.com/graphql',
     'portal' => 'APPNAME.administrateweblink.com',
+    'client' => 'CLIENT_INITIALS-booking-portal',
     'portalToken' => 'Tcdg...DIY9o',
 ];
 
@@ -289,6 +292,7 @@ $params = [
     'oauthServer' => 'https://portal-auth.administratehq.com', // Administrate weblink authorization endpoint
     'apiUri' => 'https://weblink-api.administratehq.com/graphql', // Administrate Weblink endpoint
     'portal' => 'APPNAME.administrateweblink.com',
+    'client' => 'CLIENT_INITIALS-booking-portal',
     'portalToken' => 'Tcdg...DIY9o',
 ];
 
@@ -339,6 +343,7 @@ $params = [
     'oauthServer' => 'https://portal-auth.administratehq.com', // Administrate weblink authorization endpoint
     'apiUri' => 'https://weblink-api.administratehq.com/graphql',
     'portal' => 'APPNAME.administrateweblink.com',
+    'client' => 'CLIENT_INITIALS-booking-portal',
     'portalToken' => 'Tcdg...DIY9o',
 ];
 

--- a/vendor/administrate/phpsdk/examples/config-sample.php
+++ b/vendor/administrate/phpsdk/examples/config-sample.php
@@ -32,5 +32,6 @@ $weblinkActivationParams = array(
     'oauthServer' => '',
     'apiUri' => '',
     'portal' => '',
-    'portalToken' => ''
+    'portalToken' => '',
+    'client' => ''
 );

--- a/vendor/administrate/phpsdk/src/GraphQl/Client.php
+++ b/vendor/administrate/phpsdk/src/GraphQl/Client.php
@@ -36,6 +36,10 @@ class Client extends GqlClient
             $headers['weblink-portal'] = $params['portal'];
         }
 
+        if (isset($params['client']) && !empty($params['client'])) {
+            $headers['weblink-client'] = $params['client'];
+        }
+
         return $headers;
     }
 


### PR DESCRIPTION
In this commit we are adding a new setting param to save and use the client identifier/website identifier value and pass it in the weblink API header as a value for weblink-client, this will enable us to track the API calls and identify what app/website is consuming the weblink APIs.
The initial value of this filed _(once the plugin is activated)_  will be driven from WordPress site name that can be found and edited under `/wp-admin/options-general.php` as **"Site Title"**
This setting field value can be defined/overridden using `ADMWPP_WEBLINK_CLIENT` in wp-config.php

https://administrate.atlassian.net/browse/PLAT-20074
![Screen Shot 2022-09-15 at 11 45 20 AM](https://user-images.githubusercontent.com/58948488/190358643-d1b32e5b-630f-44ab-879f-562c73d9283b.png)

or for example in wp-config.php

`define('ADMWPP_WEBLINK_CLIENT', 'cga-booking-portal-local');`
