### PR TITLE
NI-5748 Bump plugin version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Requires at least: 5.0.0
 
 Tested up to: 5.3.2
 
-Stable tag: 1.0.0
+Stable tag: 1.1.0
 
 License: GPLv2 or later
 
@@ -343,6 +343,9 @@ To a certain extent those are more or less self explanatory on how to use and ex
 * The [PHP SDK](https://packagist.org/packages/administrate/phpsdk) is also hosted on [Packagist](https://packagist.org/) so it can be used as stand alone.
 
 ## Change log
+
+### 1.1.0 
+* The Bundled Learning Paths shortcode `[admwpp-bundled-lps]` will now not display sold out Learning Paths
 
 ### 1.0.0
 * Setting pages to enter activation credentials and default parameters.

--- a/administrate-wp-plugin.php
+++ b/administrate-wp-plugin.php
@@ -2,7 +2,7 @@
 /*
   Plugin Name: Administrate
   Description: Administrate WordPress Plugin to facilitate the integration and synchronization of TMS content into WordPress content and Taxonomies, with the ability to display the content in templates using short-codes / custom filters / template overrides.
-  Version: 1.0.0
+  Version: 1.1.0
   Author: Administrate
   Author URI: http://getadministrate.com/
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "administrate-wp-plugin",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "administrate-wp-plugin",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The previously code change from https://github.com/Administrate/administrate-wp-plugin/pull/151 also required a version bump otherwise the wordpress site will not update the plugin correctly when uploading a ZIP file.

https://administrate.atlassian.net/browse/NI-5748