### PR TITLE
NI-6108 Fix `evening` `timeOfDay` filter period

### DIFF
--- a/src/Api/Search.php
+++ b/src/Api/Search.php
@@ -347,15 +347,15 @@ if (!class_exists('Search')) {
                 switch ($params['timeofday']) {
                     case 'morning':
                         $sessionStartTime = "00:00:00";
-                        $sessionEndTime = "12:01:00";
+                        $sessionEndTime = "12:00:01";
                         break;
                     case 'afternoon':
                         $sessionStartTime = "12:00:00";
-                        $sessionEndTime = "17:01:00";
+                        $sessionEndTime = "17:00:01";
                         break;
                     case 'evening':
                         $sessionStartTime = "17:00:00";
-                        $sessionEndTime = "00:01:00";
+                        $sessionEndTime = "23:59:59";
                         break;
                     default:
                         $sessionStartTime = "00:00:00";


### PR DESCRIPTION
This commit fixes the `evening` period of the time of day filter. In #146 the `sessionEndTime` was set to 00:01:00, which is incorrect because when we send these two filters together, graphql assumes that they’re both referring to the same day. So since the `sessionEndTime` was the very early morning as opposed to end of the day, it was trying to find Events which end before 00:01 in the morning but also somehow don’t start til after 5pm that same day. This is impossible.

As part of this fix we are also updating the other `timeOfDay` periods to the times requested by CGA.

https://administrate.atlassian.net/browse/NI-6108