### PR TITLE
PLAT-25546 Fix XSS security vulnerability in Search Form

### DIFF
--- a/templates/search/date-filter.php
+++ b/templates/search/date-filter.php
@@ -1,10 +1,10 @@
 <div class="row admwpp-date-filter">
     <div class='col-xs-12 col-sm-6'>
         <input type="text" placeholder="<?php _e('From date', 'admwpp'); ?>" class="admwpp-date admwpp-from-date" id="from" name="from"
-    <?php echo (isset($_GET['from']) && !empty($_GET['from']))?'value="' . $_GET['from'] . '"':''; ?> autocomplete="off">
+    <?php echo (isset($_GET['from']) && !empty($_GET['from']))?'value="' . htmlspecialchars($_GET['from']) . '"':''; ?> autocomplete="off">
     </div>
     <div class='col-xs-12 col-sm-6'>
         <input type="text" placeholder="<?php _e('To date', 'admwpp'); ?>" class="admwpp-date admwpp-to-date" id="to" name="to"
-        <?php echo (isset($_GET['to']) && !empty($_GET['to']))?'value="' . $_GET['to'] . '"':''; ?> autocomplete="off">
+        <?php echo (isset($_GET['to']) && !empty($_GET['to']))?'value="' . htmlspecialchars($_GET['to']) . '"':''; ?> autocomplete="off">
     </div>
 </div>


### PR DESCRIPTION
This commit fixes a cross site scripting vulnerability that allowed users to inject HTML content into the page via URL query parameters if the `admwpp-search-form` shortcode was being used. This commit fixes it by passing the query parameter value through the built-in `htmlspecialchars` function before outputting it.

I also briefly reviewed other usages of query parameters and didn't see any other potential issues.

https://administrate.atlassian.net/browse/PLAT-25546